### PR TITLE
This is gross and need to test it more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 Gemfile.lock
 last_modified_at.json
 *.gem
+*.swp

--- a/lib/jekyll_last_modified_at/db.rb
+++ b/lib/jekyll_last_modified_at/db.rb
@@ -2,6 +2,16 @@ module JekyllLastModifiedAt
   class FileDB
     DATABASE = "last_modified_at.json"
 
+    @@cache = {}
+
+    def self.cache(name)
+      if @@cache.empty?
+        @@cache = read_all
+      end
+
+      @@cache[name]
+    end
+
     def self.read(name)
       read_all[name]
     end

--- a/lib/jekyll_last_modified_at/entry.rb
+++ b/lib/jekyll_last_modified_at/entry.rb
@@ -30,7 +30,7 @@ module JekyllLastModifiedAt
     end
 
     def to_liquid
-      "#{last_modified_at.iso8601}"
+      "#{last_modified_at.strftime("%Y-%m-%d")}"
     end
   end
 end

--- a/lib/jekyll_last_modified_at/tag.rb
+++ b/lib/jekyll_last_modified_at/tag.rb
@@ -7,8 +7,6 @@ module JekyllLastModifiedAt
       if text.include?("IGNORE")
         text = nil
       end
-      # require 'pry'
-      # binding.pry
       page = context['page']["relative_path"]
 
       entry = JekyllLastModifiedAt::FileDB.read(page)

--- a/lib/jekyll_last_modified_at/tag.rb
+++ b/lib/jekyll_last_modified_at/tag.rb
@@ -4,7 +4,12 @@ module JekyllLastModifiedAt
   class LastModifiedBlock < ::Liquid::Block
     def render(context)
       text = super
-      page = context['page'].relative_path
+      if text.include?("IGNORE")
+        text = nil
+      end
+      # require 'pry'
+      # binding.pry
+      page = context['page']["relative_path"]
 
       entry = JekyllLastModifiedAt::FileDB.read(page)
       if entry

--- a/lib/jekyll_last_modified_at/tag.rb
+++ b/lib/jekyll_last_modified_at/tag.rb
@@ -13,7 +13,7 @@ module JekyllLastModifiedAt
       if entry
         "#{text}#{entry.to_liquid}"
       else
-        "#{text}#{Time.now.iso8601}"
+        "#{text}#{Time.now.strftime("%Y-%m-%d")}"
       end
     end
   end

--- a/lib/jekyll_last_modified_at/tag.rb
+++ b/lib/jekyll_last_modified_at/tag.rb
@@ -9,7 +9,7 @@ module JekyllLastModifiedAt
       end
       page = context['page']["relative_path"]
 
-      entry = JekyllLastModifiedAt::FileDB.read(page)
+      entry = JekyllLastModifiedAt::FileDB.cache(page)
       if entry
         "#{text}#{entry.to_liquid}"
       else

--- a/spec/jekyll_last_modified_at/entry_spec.rb
+++ b/spec/jekyll_last_modified_at/entry_spec.rb
@@ -21,6 +21,6 @@ RSpec.describe JekyllLastModifiedAt::Entry do
   end
 
   it "to_liquid" do
-    expect(entry.to_liquid).to eq(last_modified_at.iso8601)
+    expect(entry.to_liquid).to eq(last_modified_at.strftime("%Y-%m-%d"))
   end
 end

--- a/spec/jekyll_last_modified_at/tag_spec.rb
+++ b/spec/jekyll_last_modified_at/tag_spec.rb
@@ -13,8 +13,16 @@ RSpec.describe JekyllLastModifiedAt::LastModifiedBlock do
   end
 
   context "documents" do
+    let(:file) do
+      double("File", relative_path: "my_file")
+    end
+
     let(:page) do
-      instance_double(Jekyll::Drops::DocumentDrop, to_liquid: double("File", relative_path: "my_file"))
+      instance_double(Jekyll::Drops::DocumentDrop, to_liquid: file)
+    end
+
+    before(:each) do
+      allow(file).to receive(:[]).with("relative_path").and_return(file.relative_path)
     end
 
     it "finds the last_modified_at if found" do

--- a/spec/jekyll_last_modified_at/tag_spec.rb
+++ b/spec/jekyll_last_modified_at/tag_spec.rb
@@ -35,18 +35,18 @@ RSpec.describe JekyllLastModifiedAt::LastModifiedBlock do
 
       template = Liquid::Template.parse("{% last_modified_at %}last_modified_at: {% endlast_modified_at %}")
 
-      expect(template.render("page" => page)).to eq("last_modified_at: #{last_modified_at.iso8601}")
+      expect(template.render("page" => page)).to eq("last_modified_at: #{last_modified_at.strftime("%Y-%m-%d")}")
     end
 
     it "renders current time if last_modified_at is not found" do
 
       template = Liquid::Template.parse("{% last_modified_at %} last_modified_at: {% endlast_modified_at %}")
 
-      utc = Time.now.iso8601
+      utc = Time.now
       time = instance_double(Time, iso8601: utc)
       allow(Time).to receive(:now).and_return(time)
 
-      expect(template.render("page" => page)).to include(utc)
+      expect(template.render("page" => page)).to include(utc.strftime("%Y-%m-%d"))
     end
   end
 end


### PR DESCRIPTION
For some reason blocks are only called if text is included in them, ie:

```ruby
{% some_block %}
hello
{% end %}
```

but this doesn't call the tag function...


```ruby
{% some_block %}
{% end %}
```
